### PR TITLE
Renamed MaxLifeTime as MaxAnimationLifeTime and moved it from the imp…

### DIFF
--- a/AnyiQuack.pas
+++ b/AnyiQuack.pas
@@ -479,7 +479,7 @@ type
   function MatchID(CompareID, CurrentID: Integer): Boolean;
 
 const
-  MaxAnimationLifeTime = 10000;
+  MaxLifeTime = 10000;
 
 implementation
 
@@ -1206,9 +1206,9 @@ end;
 
 function TAQ.EachAnimation(Duration: Integer; Each, LastEach: TEachFunction; ID: Integer): TAQ;
 begin
-  if Duration >= MaxAnimationLifeTime then
-    raise EAQ.CreateFmt('Duration of the animation (%d) should be lower than MaxAnimationLifeTime (%d)',
-      [Duration, MaxAnimationLifeTime])
+  if Duration >= MaxLifeTime then
+    raise EAQ.CreateFmt('Duration of the animation (%d) should be lower than MaxLifeTime (%d)',
+      [Duration, MaxLifeTime])
   else if SupervisorLock(Result, aqmEachAnimation) then
     Exit;
   AddInterval(TInterval.Finite(Duration, Each, LastEach, arAnimation, ID));
@@ -1216,9 +1216,9 @@ end;
 
 function TAQ.EachDelay(Delay: Integer; Each: TEachFunction; ID: Integer): TAQ;
 begin
-  if Delay >= MaxAnimationLifeTime then
-    raise EAQ.CreateFmt('Delay (%d) must be lower than MaxAnimationLifeTime (%d)',
-      [Delay, MaxAnimationLifeTime])
+  if Delay >= MaxLifeTime then
+    raise EAQ.CreateFmt('Delay (%d) must be lower than MaxLifeTime (%d)',
+      [Delay, MaxLifeTime])
   else if SupervisorLock(Result, aqmEachDelay) then
      Exit;
   AddInterval(TInterval.Finite(Delay, nil, Each, arDelay, ID));
@@ -1231,9 +1231,9 @@ end;
 // objects, you should define an ID, so you'll be able to cancel only the specific intervaled Each.
 function TAQ.EachInterval(Interval: Integer; Each: TEachFunction; ID: Integer): TAQ;
 begin
-  if Interval >= MaxAnimationLifeTime then
-    raise EAQ.CreateFmt('Interval (%d) must be lower than MaxAnimationLifeTime (%d)',
-      [Interval, MaxAnimationLifeTime])
+  if Interval >= MaxLifeTime then
+    raise EAQ.CreateFmt('Interval (%d) must be lower than MaxLifeTime (%d)',
+      [Interval, MaxLifeTime])
   else if SupervisorLock(Result, aqmEachInterval) then
     Exit;
   AddInterval(TInterval.Infinite(Interval, Each, arInterval, ID));
@@ -1258,9 +1258,9 @@ end;
 // e.g. `AQ.CurrentInterval.Progress`
 function TAQ.EachTimer(Duration: Integer; Each, LastEach: TEachFunction; ID: Integer): TAQ;
 begin
-  if Duration >= MaxAnimationLifeTime then
-    raise EAQ.CreateFmt('Timers duration (%d) must be lower than MaxAnimationLifeTime (%d)',
-      [Duration, MaxAnimationLifeTime])
+  if Duration >= MaxLifeTime then
+    raise EAQ.CreateFmt('Timers duration (%d) must be lower than MaxLifeTime (%d)',
+      [Duration, MaxLifeTime])
   else if SupervisorLock(Result, aqmEachTimer) then
     Exit;
   AddInterval(TInterval.Finite(Duration, Each, LastEach, arTimer, ID));
@@ -2126,7 +2126,7 @@ end;
 
 function TAQ.IsAlive: Boolean;
 begin
-  Result := ((FLifeTick + MaxAnimationLifeTime) >= TAQ.Tick) or Immortally;
+  Result := ((FLifeTick + MaxLifeTime) >= TAQ.Tick) or Immortally;
 end;
 
 procedure TAQ.LocalIntervalTimerEvent;

--- a/AnyiQuack.pas
+++ b/AnyiQuack.pas
@@ -478,10 +478,12 @@ type
 
   function MatchID(CompareID, CurrentID: Integer): Boolean;
 
+const
+  MaxAnimationLifeTime = 10000;
+
 implementation
 
 const
-  MaxLifeTime = 10000;
 {$IFDEF UseThreadTimer}
   IntervalResolution = 15;
 {$ELSE}
@@ -1204,9 +1206,9 @@ end;
 
 function TAQ.EachAnimation(Duration: Integer; Each, LastEach: TEachFunction; ID: Integer): TAQ;
 begin
-  if Duration >= MaxLifeTime then
-    raise EAQ.CreateFmt('Duration of the animation (%d) should be lower than MaxLifeTime (%d)',
-      [Duration, MaxLifeTime])
+  if Duration >= MaxAnimationLifeTime then
+    raise EAQ.CreateFmt('Duration of the animation (%d) should be lower than MaxAnimationLifeTime (%d)',
+      [Duration, MaxAnimationLifeTime])
   else if SupervisorLock(Result, aqmEachAnimation) then
     Exit;
   AddInterval(TInterval.Finite(Duration, Each, LastEach, arAnimation, ID));
@@ -1214,9 +1216,9 @@ end;
 
 function TAQ.EachDelay(Delay: Integer; Each: TEachFunction; ID: Integer): TAQ;
 begin
-  if Delay >= MaxLifeTime then
-    raise EAQ.CreateFmt('Delay (%d) must bew lower than MaxLifeTime (%d)',
-      [Delay, MaxLifeTime])
+  if Delay >= MaxAnimationLifeTime then
+    raise EAQ.CreateFmt('Delay (%d) must be lower than MaxAnimationLifeTime (%d)',
+      [Delay, MaxAnimationLifeTime])
   else if SupervisorLock(Result, aqmEachDelay) then
      Exit;
   AddInterval(TInterval.Finite(Delay, nil, Each, arDelay, ID));
@@ -1229,9 +1231,9 @@ end;
 // objects, you should define an ID, so you'll be able to cancel only the specific intervaled Each.
 function TAQ.EachInterval(Interval: Integer; Each: TEachFunction; ID: Integer): TAQ;
 begin
-  if Interval >= MaxLifeTime then
-    raise EAQ.CreateFmt('Interval (%d) must be lower than MaxLifeTime (%d)',
-      [Interval, MaxLifeTime])
+  if Interval >= MaxAnimationLifeTime then
+    raise EAQ.CreateFmt('Interval (%d) must be lower than MaxAnimationLifeTime (%d)',
+      [Interval, MaxAnimationLifeTime])
   else if SupervisorLock(Result, aqmEachInterval) then
     Exit;
   AddInterval(TInterval.Infinite(Interval, Each, arInterval, ID));
@@ -1256,9 +1258,9 @@ end;
 // e.g. `AQ.CurrentInterval.Progress`
 function TAQ.EachTimer(Duration: Integer; Each, LastEach: TEachFunction; ID: Integer): TAQ;
 begin
-  if Duration >= MaxLifeTime then
-    raise EAQ.CreateFmt('Timers duration (%d) must be lower than MaxLifeTime (%d)',
-      [Duration, MaxLifeTime])
+  if Duration >= MaxAnimationLifeTime then
+    raise EAQ.CreateFmt('Timers duration (%d) must be lower than MaxAnimationLifeTime (%d)',
+      [Duration, MaxAnimationLifeTime])
   else if SupervisorLock(Result, aqmEachTimer) then
     Exit;
   AddInterval(TInterval.Finite(Duration, Each, LastEach, arTimer, ID));
@@ -2124,7 +2126,7 @@ end;
 
 function TAQ.IsAlive: Boolean;
 begin
-  Result := ((FLifeTick + MaxLifeTime) >= TAQ.Tick) or Immortally;
+  Result := ((FLifeTick + MaxAnimationLifeTime) >= TAQ.Tick) or Immortally;
 end;
 
 procedure TAQ.LocalIntervalTimerEvent;


### PR DESCRIPTION
…lementation section to the interface section, so that one can perform checking against it to avoid exception error messsages such as 'Delay (11000) must be lower than MaxLifeTime (10000)'

And fixed a typo.